### PR TITLE
extent audience conformance tests for complete lifecycle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/venturemark/fmz
 go 1.15
 
 require (
-	github.com/venturemark/apigengo v0.0.0-20210114083259-2aab618959c2
+	github.com/venturemark/apigengo v0.0.0-20210115214846-44f82a16198f
 	github.com/xh3b4sd/tracer v0.3.1
 	google.golang.org/grpc v1.35.0
 )

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/venturemark/apigengo v0.0.0-20210114083259-2aab618959c2 h1:0H/gLtE2R+hVT3A2nyrLopJZev1djEKdiPxyzdrTEmQ=
-github.com/venturemark/apigengo v0.0.0-20210114083259-2aab618959c2/go.mod h1:Vh1j2Yvbdui2WYbByYto5AJbhYdkpP6VRz2d6P4PhqM=
+github.com/venturemark/apigengo v0.0.0-20210115214846-44f82a16198f h1:BF+tPCjgdb93fEWLazrVuozrfSJdFcJSBVuEzGD0ry4=
+github.com/venturemark/apigengo v0.0.0-20210115214846-44f82a16198f/go.mod h1:Vh1j2Yvbdui2WYbByYto5AJbhYdkpP6VRz2d6P4PhqM=
 github.com/xh3b4sd/tracer v0.3.1 h1:wv4Cy/u/xLXLUJeKQWeiR+aU4mywj2f8PkQVda1EXKQ=
 github.com/xh3b4sd/tracer v0.3.1/go.mod h1:ZOLvBVLrmNx3GLCL7j0vEGMuI3r5ltLFcmDjG/3nV7g=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/tst/audience_test.go
+++ b/tst/audience_test.go
@@ -25,6 +25,7 @@ func Test_Audience_001(t *testing.T) {
 		defer cli.Connection().Close()
 	}
 
+	var aid string
 	{
 		i := &audience.CreateI{
 			Obj: &audience.CreateI_Obj{
@@ -47,10 +48,12 @@ func Test_Audience_001(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, ok := o.Obj.Metadata["audience.venturemark.co/id"]
+		s, ok := o.Obj.Metadata["audience.venturemark.co/id"]
 		if !ok {
 			t.Fatal("audience ID must not be empty")
 		}
+
+		aid = s
 	}
 
 	{
@@ -73,6 +76,114 @@ func Test_Audience_001(t *testing.T) {
 		_, err := cli.Audience().Create(context.Background(), i)
 		if err == nil {
 			t.Fatal("audience name must be unique")
+		}
+	}
+
+	{
+		i := &audience.DeleteI{
+			Obj: &audience.DeleteI_Obj{
+				Metadata: map[string]string{
+					"audience.venturemark.co/id":     aid,
+					"organization.venturemark.co/id": "org",
+					"user.venturemark.co/id":         "usr",
+				},
+			},
+		}
+
+		o, err := cli.Audience().Delete(context.Background(), i)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		s, ok := o.Obj.Metadata["audience.venturemark.co/status"]
+		if !ok {
+			t.Fatal("audience ID must not be empty")
+		}
+
+		if s != "deleted" {
+			t.Fatal("audience status must be deleted")
+		}
+	}
+
+	{
+		i := &audience.CreateI{
+			Obj: &audience.CreateI_Obj{
+				Metadata: map[string]string{
+					"organization.venturemark.co/id": "org",
+					"user.venturemark.co/id":         "usr",
+				},
+				Property: &audience.CreateI_Obj_Property{
+					Name: "Employees",
+					User: []string{
+						"xh3b4sd",
+						"marcoelli",
+					},
+				},
+			},
+		}
+
+		o, err := cli.Audience().Create(context.Background(), i)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		s, ok := o.Obj.Metadata["audience.venturemark.co/id"]
+		if !ok {
+			t.Fatal("audience ID must not be empty")
+		}
+
+		aid = s
+	}
+
+	{
+		i := &audience.SearchI{
+			Obj: []*audience.SearchI_Obj{
+				{
+					Metadata: map[string]string{
+						"organization.venturemark.co/id": "org",
+						"user.venturemark.co/id":         "usr",
+					},
+				},
+			},
+		}
+
+		o, err := cli.Audience().Search(context.Background(), i)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if len(o.Obj) != 1 {
+			t.Fatal("there must be one audience")
+		}
+
+		if o.Obj[0].Property.Name != "Employees" {
+			t.Fatal("audience name must be Employees")
+		}
+	}
+
+	{
+		i := &audience.DeleteI{
+			Obj: &audience.DeleteI_Obj{
+				Metadata: map[string]string{
+					"audience.venturemark.co/id":     aid,
+					"organization.venturemark.co/id": "org",
+					"user.venturemark.co/id":         "usr",
+				},
+			},
+		}
+
+		o, err := cli.Audience().Delete(context.Background(), i)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		s, ok := o.Obj.Metadata["audience.venturemark.co/status"]
+		if !ok {
+			t.Fatal("audience ID must not be empty")
+		}
+
+		if s != "deleted" {
+			t.Fatal("audience status must be deleted")
 		}
 	}
 }


### PR DESCRIPTION
Towards https://github.com/venturemark/apiserver/pull/78. 